### PR TITLE
refactor: adapt LogManager for Monolog v2 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 You can see the changes made via the [commit log](https://github.com/themehybrid/hybrid-log/commits/master) for the latest release.
 
+## [1.0.0-beta.4] - 2024-08-21
+
+### Changed
+
+- Refactor: Ensure LogManager compatibility with Monolog v2 and adjust code for LogRecord array support.
+
 ## [1.0.0-beta.3] - 2024-08-02
 
 ### Changed
@@ -13,6 +19,7 @@ You can see the changes made via the [commit log](https://github.com/themehybrid
 - Lint composer.json
 - Lint php
 - Update copyright date
+- Added: Context support to the log package, enabling better contextual logging within the applications.
 
 ## [1.0.0-beta.2] - 2024-06-24
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ You need to register the service provider during your bootstrapping process:
 
 ```php
 $slug->provider( \Hybrid\Log\Provider::class );
+$slug->provider( \Hybrid\Log\Context\Provider::class );
 ```
 
 Sample `/config/logging.php`
@@ -112,6 +113,10 @@ Sample usage
 
 ```php
 use Hybrid\Log\Facades\Log;
+use Hybrid\Log\Facades\Context;
+
+Context::add('some_key', 'value');
+Context::add('some_other_key', 'value');
 
 Log::emergency($message);
 Log::alert($message);

--- a/src/Context/Provider.php
+++ b/src/Context/Provider.php
@@ -4,7 +4,7 @@ namespace Hybrid\Log\Context;
 
 use Hybrid\Core\ServiceProvider;
 
-class ContextServiceProvider extends ServiceProvider {
+class Provider extends ServiceProvider {
 
     /**
      * Register the service provider.

--- a/src/Facades/Context.php
+++ b/src/Facades/Context.php
@@ -2,6 +2,8 @@
 
 namespace Hybrid\Log\Facades;
 
+use Hybrid\Core\Facades\Facade;
+
 /**
  * @see \Hybrid\Log\Context\Repository
  *

--- a/src/LogManager.php
+++ b/src/LogManager.php
@@ -142,6 +142,21 @@ class LogManager implements LoggerInterface {
                             return $record;
                         }
 
+                        // Handling Monolog v2 compatibility until the framework supports PHP 8.1+,
+                        // as Monolog v3 requires a minimum of PHP 8.1.
+                        // For Monolog v2, $record is an array, so we merge the existing 'extra' data
+                        // with the new context data. This will ensure compatibility with both versions.
+                        if ( ! ( $record instanceof \Monolog\LogRecord ) ) {
+                            $extraData = $this->app[ ContextRepository::class ]->all();
+
+                            $existingExtra   = isset( $record['extra'] ) && is_array( $record['extra'] )
+                                ? $record['extra']
+                                : [];
+                            $record['extra'] = array_merge( $existingExtra, $extraData );
+
+                            return $record;
+                        }
+
                         // Note: Downgraded it to ensure PHP 8.0 compatibility,
                         // as it relies on the array unpacking feature with the spread operator (...),
                         // which was introduced in PHP 7.4 for arrays but could not be used in such a context until PHP >=8.1.


### PR DESCRIPTION
* Refactor logger implementation to ensure compatibility with Monolog v2.
* Downgrade Monolog-specific code to support the LogRecord interface as an array.
* Add necessary imports for the Context Facade to maintain functionality.